### PR TITLE
Give an API Endpoint its own data type

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+# Use new container infrastructure to enable caching
+sudo: false
+
+# Choose a lightweight base image; we provide our own build tools.
+language: c
+
+# GHC depends on GMP. You can add other dependencies here as well.
+addons:
+  apt:
+    packages:
+    - libgmp-dev
+
+# We want support for GHC 8.4 & 8.6 with associated resolvers
+env:
+- ARGS="--resolver lts-12"
+- ARGS="--resolver lts-13"
+
+before_install:
+# Download and unpack the stack executable
+- mkdir -p ~/.local/bin
+- export PATH=$HOME/.local/bin:$PATH
+- travis_retry curl -L https://www.stackage.org/stack/linux-x86_64 | tar xz --wildcards --strip-components=1 -C ~/.local/bin '*/stack'
+
+# This line does all of the work: installs GHC if necessary, build the library,
+# executables, and test suites, and runs the test suites. --no-terminal works
+# around some quirks in Travis's terminal implementation.
+script: stack $ARGS --no-terminal --install-ghc test --haddock
+
+# Caching so the next build will be fast too.
+cache:
+  directories:
+  - $HOME/.stack

--- a/lib/Servant/Prometheus/Class.hs
+++ b/lib/Servant/Prometheus/Class.hs
@@ -1,0 +1,166 @@
+{-# LANGUAGE CPP                 #-}
+{-# LANGUAGE DataKinds           #-}
+{-# LANGUAGE DeriveAnyClass      #-}
+{-# LANGUAGE DeriveGeneric       #-}
+{-# LANGUAGE FlexibleContexts    #-}
+{-# LANGUAGE FlexibleInstances   #-}
+{-# LANGUAGE KindSignatures      #-}
+{-# LANGUAGE OverloadedStrings   #-}
+{-# LANGUAGE PolyKinds           #-}
+{-# LANGUAGE RecordWildCards     #-}
+{-# LANGUAGE ScopedTypeVariables #-}
+{-# LANGUAGE TypeOperators       #-}
+
+module Servant.Prometheus.Class (
+  HasEndpoint(..),
+  Endpoint(..)
+) where
+
+
+import           Control.Monad
+import           Data.Hashable      (Hashable (..))
+import           Data.Monoid        ((<>))
+import           Data.Proxy         (Proxy (..))
+import           Data.Text          (Text)
+import qualified Data.Text          as T
+import           GHC.Generics       (Generic)
+import           GHC.TypeLits
+import           Network.HTTP.Types (Method)
+import           Network.Wai        (Request, pathInfo, requestMethod)
+import           Servant.API
+
+data Endpoint = Endpoint
+  { pathSegments :: [Text]
+  , method       :: Method
+  } deriving (Eq, Hashable, Show, Generic)
+
+
+class HasEndpoint a where
+  getEndpoint        :: Proxy a -> Request -> Maybe Endpoint
+  enumerateEndpoints :: Proxy a -> [Endpoint]
+
+
+instance HasEndpoint EmptyAPI where
+  getEndpoint      _ _ = Nothing
+  enumerateEndpoints _ = []
+
+instance (HasEndpoint (a :: *), HasEndpoint (b :: *)) => HasEndpoint (a :<|> b) where
+    getEndpoint _ req =
+                getEndpoint (Proxy :: Proxy a) req
+        `mplus` getEndpoint (Proxy :: Proxy b) req
+
+    enumerateEndpoints _ =
+           enumerateEndpoints (Proxy :: Proxy a)
+        <> enumerateEndpoints (Proxy :: Proxy b)
+
+instance (KnownSymbol (path :: Symbol), HasEndpoint (sub :: *))
+    => HasEndpoint (path :> sub) where
+    getEndpoint _ req =
+        case pathInfo req of
+            p:ps | p == T.pack (symbolVal (Proxy :: Proxy path)) -> do
+                Endpoint{..} <- getEndpoint (Proxy :: Proxy sub) req{ pathInfo = ps }
+                return (Endpoint (p:pathSegments) method)
+            _ -> Nothing
+
+    enumerateEndpoints _ =
+        let endpoints               = enumerateEndpoints (Proxy :: Proxy sub)
+            currentSegment          = T.pack $ symbolVal (Proxy :: Proxy path)
+            qualify Endpoint{..} = Endpoint (currentSegment : pathSegments) method
+        in
+            map qualify endpoints
+
+instance (KnownSymbol (capture :: Symbol), HasEndpoint (sub :: *))
+    => HasEndpoint (Capture' mods capture a :> sub) where
+    getEndpoint _ req =
+        case pathInfo req of
+            _:ps -> do
+                Endpoint{..} <- getEndpoint (Proxy :: Proxy sub) req{ pathInfo = ps }
+                let p = T.pack $ (':':) $ symbolVal (Proxy :: Proxy capture)
+                return (Endpoint (p:pathSegments) method)
+            _ -> Nothing
+    enumerateEndpoints _ =
+        let endpoints               = enumerateEndpoints (Proxy :: Proxy sub)
+            currentSegment          = T.pack $ (':':) $ symbolVal (Proxy :: Proxy capture)
+            qualify Endpoint{..} = Endpoint (currentSegment : pathSegments) method
+        in
+            map qualify endpoints
+
+instance HasEndpoint (sub :: *) => HasEndpoint (Summary d :> sub) where
+    getEndpoint        _ = getEndpoint        (Proxy :: Proxy sub)
+    enumerateEndpoints _ = enumerateEndpoints (Proxy :: Proxy sub)
+
+instance HasEndpoint (sub :: *) => HasEndpoint (Description d :> sub) where
+    getEndpoint        _ = getEndpoint        (Proxy :: Proxy sub)
+    enumerateEndpoints _ = enumerateEndpoints (Proxy :: Proxy sub)
+
+instance HasEndpoint (sub :: *) => HasEndpoint (Header' mods h a :> sub) where
+    getEndpoint        _ = getEndpoint        (Proxy :: Proxy sub)
+    enumerateEndpoints _ = enumerateEndpoints (Proxy :: Proxy sub)
+
+instance HasEndpoint (sub :: *) => HasEndpoint (QueryParam' mods (h :: Symbol) a :> sub) where
+    getEndpoint        _ = getEndpoint        (Proxy :: Proxy sub)
+    enumerateEndpoints _ = enumerateEndpoints (Proxy :: Proxy sub)
+
+instance HasEndpoint (sub :: *) => HasEndpoint (QueryParams (h :: Symbol) a :> sub) where
+    getEndpoint        _ = getEndpoint        (Proxy :: Proxy sub)
+    enumerateEndpoints _ = enumerateEndpoints (Proxy :: Proxy sub)
+
+instance HasEndpoint (sub :: *) => HasEndpoint (QueryFlag h :> sub) where
+    getEndpoint        _ = getEndpoint        (Proxy :: Proxy sub)
+    enumerateEndpoints _ = enumerateEndpoints (Proxy :: Proxy sub)
+
+instance HasEndpoint (sub :: *) => HasEndpoint (ReqBody' mods cts a :> sub) where
+    getEndpoint        _ = getEndpoint        (Proxy :: Proxy sub)
+    enumerateEndpoints _ = enumerateEndpoints (Proxy :: Proxy sub)
+
+#if MIN_VERSION_servant(0,15,0)
+instance HasEndpoint (sub :: *) => HasEndpoint (StreamBody' mods framing ct a :> sub) where
+    getEndpoint        _ = getEndpoint        (Proxy :: Proxy sub)
+    enumerateEndpoints _ = enumerateEndpoints (Proxy :: Proxy sub)
+#endif
+
+instance HasEndpoint (sub :: *) => HasEndpoint (RemoteHost :> sub) where
+    getEndpoint        _ = getEndpoint        (Proxy :: Proxy sub)
+    enumerateEndpoints _ = enumerateEndpoints (Proxy :: Proxy sub)
+
+instance HasEndpoint (sub :: *) => HasEndpoint (IsSecure :> sub) where
+    getEndpoint        _ = getEndpoint        (Proxy :: Proxy sub)
+    enumerateEndpoints _ = enumerateEndpoints (Proxy :: Proxy sub)
+
+instance HasEndpoint (sub :: *) => HasEndpoint (HttpVersion :> sub) where
+    getEndpoint        _ = getEndpoint        (Proxy :: Proxy sub)
+    enumerateEndpoints _ = enumerateEndpoints (Proxy :: Proxy sub)
+
+instance HasEndpoint (sub :: *) => HasEndpoint (Vault :> sub) where
+    getEndpoint        _ = getEndpoint        (Proxy :: Proxy sub)
+    enumerateEndpoints _ = enumerateEndpoints (Proxy :: Proxy sub)
+
+instance HasEndpoint (sub :: *) => HasEndpoint (WithNamedContext x y sub) where
+    getEndpoint        _ = getEndpoint        (Proxy :: Proxy sub)
+    enumerateEndpoints _ = enumerateEndpoints (Proxy :: Proxy sub)
+
+instance ReflectMethod method => HasEndpoint (Verb method status cts a) where
+    getEndpoint _ req = case pathInfo req of
+        [] | requestMethod req == method -> Just (Endpoint [] method)
+        _                                -> Nothing
+        where method = reflectMethod (Proxy :: Proxy method)
+
+    enumerateEndpoints _ = [Endpoint mempty method]
+        where method = reflectMethod (Proxy :: Proxy method)
+
+instance ReflectMethod method => HasEndpoint (Stream method status framing ct a) where
+    getEndpoint _ req = case pathInfo req of
+        [] | requestMethod req == method -> Just (Endpoint [] method)
+        _                                -> Nothing
+        where method = reflectMethod (Proxy :: Proxy method)
+
+    enumerateEndpoints _ = [Endpoint mempty method]
+        where method = reflectMethod (Proxy :: Proxy method)
+
+instance HasEndpoint Raw where
+    getEndpoint      _ _ = Just (Endpoint [] "RAW")
+    enumerateEndpoints _ =      [Endpoint [] "RAW"]
+
+instance HasEndpoint (sub :: *) => HasEndpoint (CaptureAll (h :: Symbol) a :> sub) where
+    getEndpoint        _ = getEndpoint        (Proxy :: Proxy sub)
+    enumerateEndpoints _ = enumerateEndpoints (Proxy :: Proxy sub)

--- a/servant-prometheus.cabal
+++ b/servant-prometheus.cabal
@@ -1,5 +1,5 @@
 name:                servant-prometheus
-version:             0.1.0.0
+version:             0.2.0.0
 synopsis:            Helpers for using prometheus with servant
 description:         Helpers for using prometheus with servant. Each endpoint has its own metrics allowing more detailed monitoring than wai-middleware-prometheus allows
 license:             BSD3
@@ -19,15 +19,18 @@ source-repository HEAD
 library
   exposed-modules:     Servant.Prometheus
   hs-source-dirs:      lib
-  build-depends:       base >= 4.7 && < 4.12
-                     , prometheus-client >= 1.0
-                     , servant > 0.10 && < 0.14
-                     , http-types
-                     , text
-                     , time
-                     , unordered-containers
-                     , wai
-                     , bytestring
+  build-depends:      base                  >= 4.7      && < 4.13
+                    , prometheus-client     >= 1.0
+                    , servant               >= 0.14     && < 0.16
+                    , ekg-core              >= 0.1.1.4  && <0.2
+                    , http-types            >= 0.12.2   && <0.13
+                    , servant               >= 0.14     && <0.16
+                    , text                  >= 1.2.3.0  && <1.3
+                    , time                  >= 1.6.0.1  && <1.9
+                    , unordered-containers  >= 0.2.9.0  && <0.3
+                    , wai                   >= 3.2.0    && <3.3
+                    , bytestring
+
   default-language:    Haskell2010
 
 test-suite spec

--- a/servant-prometheus.cabal
+++ b/servant-prometheus.cabal
@@ -18,11 +18,13 @@ source-repository HEAD
 
 library
   exposed-modules:     Servant.Prometheus
+  other-modules:       Servant.Prometheus.Class
   hs-source-dirs:      lib
   build-depends:      base                  >= 4.7      && < 4.13
                     , prometheus-client     >= 1.0
                     , servant               >= 0.14     && < 0.16
                     , ekg-core              >= 0.1.1.4  && <0.2
+                    , hashable              >= 1.2.7.0  && <1.3
                     , http-types            >= 0.12.2   && <0.13
                     , servant               >= 0.14     && <0.16
                     , text                  >= 1.2.3.0  && <1.3

--- a/stack.yaml
+++ b/stack.yaml
@@ -1,60 +1,11 @@
-# Resolver to choose a 'specific' stackage snapshot or a compiler version.
-# A snapshot resolver dictates the compiler version and the set of packages
-# to be used for project dependencies. For example:
-#
-# resolver: lts-3.5
-# resolver: nightly-2015-09-21
-# resolver: ghc-7.10.2
-# resolver: ghcjs-0.1.0_ghc-7.10.2
-# resolver:
-#  name: custom-snapshot
-#  location: "./custom-snapshot.yaml"
-resolver: lts-11.0
+resolver: lts-12.26
 
-# User packages to be built.
-# Various formats can be used as shown in the example below.
-#
-# packages:
-# - some-directory
-# - https://example.com/foo/bar/baz-0.0.2.tar.gz
-# - location:
-#    git: https://github.com/commercialhaskell/stack.git
-#    commit: e7b331f14bcffb8367cd58fbfc8b40ec7642100a
-# - location: https://github.com/commercialhaskell/stack/commit/e7b331f14bcffb8367cd58fbfc8b40ec7642100a
-#   extra-dep: true
-#  subdirs:
-#  - auto-update
-#  - wai
-#
-# A package marked 'extra-dep: true' will only be built if demanded by a
-# non-dependency (i.e. a user package), and its test suites and benchmarks
-# will not be run. This is useful for tweaking upstream packages.
 packages:
 - '.'
-# Dependency packages to be pulled from upstream that are not in the resolver
-# (e.g., acme-missiles-0.3)
-extra-deps: []
 
-# Override default flag values for local packages and extra-deps
+extra-deps:
+- prometheus-client-1.0.0
+
 flags: {}
 
-# Extra package databases containing global packages
 extra-package-dbs: []
-
-# Control whether we use the GHC we find on the path
-# system-ghc: true
-#
-# Require a specific version of stack, using version ranges
-# require-stack-version: -any # Default
-# require-stack-version: ">=1.1"
-#
-# Override the architecture used by stack, especially useful on Windows
-# arch: i386
-# arch: x86_64
-#
-# Extra directories used by stack for building
-# extra-include-dirs: [/path/to/dir]
-# extra-lib-dirs: [/path/to/dir]
-#
-# Allow a newer minor version of GHC than the snapshot specifies
-# compiler-check: newer-minor


### PR DESCRIPTION
This builds on #11.

We call a `([Text], Method)` an `Endpoint` and reconcile the `HasMethod` typeclass with the one in haskell-servant/servant-ekg#9. For the time being, we also drop support for producing the "unknown" metric since the next change is going to mine `Endpoint`s for richer metric labels and more idiomatic metric names, and there's no obvious unknown-`Endpoint` value.